### PR TITLE
Adds support for multiple local fodlers

### DIFF
--- a/demo/astro.config.ts
+++ b/demo/astro.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "astro/config";
-import icon from "astro-icon";
+import icon from "../packages/core/src/index.js";
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [icon()],
+  integrations: [
+    icon({
+      iconDir: ["src/icons", "src/assets/icons"],
+    }),
+  ],
 });
+
+

--- a/demo/src/icons/star.svg
+++ b/demo/src/icons/star.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 17.27L18.18 21L16.54 13.97L22 9.24L14.81 8.63L12 2L9.19 8.63L2 9.24L7.46 13.97L5.82 21L12 17.27Z" fill="currentColor"/>
+</svg> 

--- a/demo/src/icons/test.svg
+++ b/demo/src/icons/test.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" fill="currentColor"/>
+</svg> 

--- a/demo/src/pages/index.astro
+++ b/demo/src/pages/index.astro
@@ -22,7 +22,8 @@ const icon = "adjustment";
     <Icon name="logos/deno" />
     <Icon width={75} name="logos/alpine" />
     <Icon name="logos/alpine-multi-color" />
-
+    <Icon name="adjustment" />  <!-- From src/icons -->
+    <Icon name="star" />       <!-- From src/assets/icons -->
     <Icon is:inline size={24} name="adjustment" />
   </article>
 

--- a/packages/core/src/vite-plugin-astro-icon.ts
+++ b/packages/core/src/vite-plugin-astro-icon.ts
@@ -23,6 +23,7 @@ export function createPlugin(
   const { root } = ctx;
   const virtualModuleId = "virtual:astro-icon";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
+  const iconDirs = Array.isArray(iconDir) ? iconDir : [iconDir];
 
   return {
     name: "astro-icon",
@@ -38,38 +39,73 @@ export function createPlugin(
           if (!collections) {
             collections = await loadIconifyCollections({ root, include });
           }
-          const local = await loadLocalCollection(iconDir, svgoOptions);
+
+          // Load and merge all local collections
+          const localCollections = await Promise.all(
+            iconDirs.map(dir => loadLocalCollection(dir, svgoOptions))
+          );
+
+          // Merge all local collections into one
+          const local = localCollections.reduce((merged, current) => ({
+            ...merged,
+            icons: { ...merged.icons, ...current.icons },
+            aliases: { ...merged.aliases, ...current.aliases },
+            prefix: "local",
+          }), { icons: {}, aliases: {}, prefix: "local" } as IconCollection);
+
           collections["local"] = local;
-          logCollections(collections, { ...ctx, iconDir });
+          logCollections(collections, { ...ctx, iconDir: iconDirs });
           await generateIconTypeDefinitions(Object.values(collections), root);
         } catch (ex) {
           // Failed to load the local collection
+          ctx.logger.error("Failed to load local icon collections:", ex);
         }
         return `export default ${JSON.stringify(collections)};\nexport const config = ${JSON.stringify({ include })}`;
       }
     },
     configureServer({ watcher, moduleGraph }) {
-      watcher.add(`${iconDir}/**/*.svg`);
+      // Watch all icon directories
+      iconDirs.forEach(dir => {
+        watcher.add(`${dir}/**/*.svg`);
+      });
+
       watcher.on("all", async (_, filepath: string) => {
         const parsedPath = parse(filepath);
-        const resolvedIconDir = resolve(root.pathname, iconDir);
-        const isSvgFileInIconDir =
-          parsedPath.dir.startsWith(resolvedIconDir) &&
-          parsedPath.ext === ".svg";
+        const isInIconDir = iconDirs.some(dir => {
+          const resolvedIconDir = resolve(root.pathname, dir);
+          return parsedPath.dir.startsWith(resolvedIconDir);
+        });
+        const isSvgFile = parsedPath.ext === ".svg";
         const isAstroConfig = parsedPath.name === "astro.config";
-        if (!isSvgFileInIconDir && !isAstroConfig) return;
+
+        if (!((isInIconDir && isSvgFile) || isAstroConfig)) return;
+
         console.log(`Local icons changed, reloading`);
         try {
           if (!collections) {
             collections = await loadIconifyCollections({ root, include });
           }
-          const local = await loadLocalCollection(iconDir, svgoOptions);
+
+          // Load and merge all local collections
+          const localCollections = await Promise.all(
+            iconDirs.map(dir => loadLocalCollection(dir, svgoOptions))
+          );
+
+          // Merge all local collections into one
+          const local = localCollections.reduce((merged, current) => ({
+            ...merged,
+            icons: { ...merged.icons, ...current.icons },
+            aliases: { ...merged.aliases, ...current.aliases },
+            prefix: "local",
+          }), { icons: {}, aliases: {}, prefix: "local" } as IconCollection);
+
           collections["local"] = local;
-          logCollections(collections, { ...ctx, iconDir });
+          logCollections(collections, { ...ctx, iconDir: iconDirs });
           await generateIconTypeDefinitions(Object.values(collections), root);
           moduleGraph.invalidateAll();
         } catch (ex) {
           // Failed to load the local collection
+          ctx.logger.error("Failed to reload local icon collections:", ex);
         }
         return `export default ${JSON.stringify(collections)};\nexport const config = ${JSON.stringify({ include })}`;
       });
@@ -79,7 +115,7 @@ export function createPlugin(
 
 function logCollections(
   collections: AstroIconCollectionMap,
-  { logger, iconDir }: PluginContext & { iconDir: string },
+  { logger, iconDir }: PluginContext & { iconDir: string | string[] },
 ) {
   if (Object.keys(collections).length === 0) {
     logger.warn("No icons detected!");
@@ -87,7 +123,8 @@ function logCollections(
   }
   const names: string[] = Object.keys(collections).filter((v) => v !== "local");
   if (collections["local"]) {
-    names.unshift(iconDir);
+    const dirs = Array.isArray(iconDir) ? iconDir : [iconDir];
+    names.unshift(...dirs);
   }
   logger.info(`Loaded icons from ${names.join(", ")}`);
 }
@@ -110,24 +147,22 @@ async function generateIconTypeDefinitions(
 // ${currentHash}
 
 declare module 'virtual:astro-icon' {
-\texport type Icon = ${
-      collections.length > 0
-        ? collections
-            .map((collection) =>
-              Object.keys(collection.icons)
-                .concat(Object.keys(collection.aliases ?? {}))
-                .map(
-                  (icon) =>
-                    `\n\t\t| "${
-                      collection.prefix === defaultPack
-                        ? ""
-                        : `${collection.prefix}:`
-                    }${icon}"`,
-                ),
-            )
-            .flat(1)
-            .join("")
-        : "never"
+\texport type Icon = ${collections.length > 0
+      ? collections
+        .map((collection) =>
+          Object.keys(collection.icons)
+            .concat(Object.keys(collection.aliases ?? {}))
+            .map(
+              (icon) =>
+                `\n\t\t| "${collection.prefix === defaultPack
+                  ? ""
+                  : `${collection.prefix}:`
+                }${icon}"`,
+            ),
+        )
+        .flat(1)
+        .join("")
+      : "never"
     };
 }`,
   );
@@ -151,11 +186,11 @@ async function tryGetHash(path: URL): Promise<string | void> {
   try {
     const text = await readFile(path, { encoding: "utf-8" });
     return text.split("\n", 3)[1].replace("// ", "");
-  } catch {}
+  } catch { }
 }
 
 async function ensureDir(path: URL): Promise<void> {
   try {
     await mkdir(path, { recursive: true });
-  } catch {}
+  } catch { }
 }

--- a/packages/core/typings/integration.d.ts
+++ b/packages/core/typings/integration.d.ts
@@ -5,7 +5,7 @@ export type IntegrationOptions = {
   /**
    * @default "src/icons"
    */
-  iconDir?: string;
+  iconDir?: string | string[];
   /**
    * @default { plugins: ['preset-default'] }
    */


### PR DESCRIPTION
Adds support for multiple local folders. as of now Astro Icon is limited to one location where we can store icons, change allows to pass array with locations into astro config, so icons can be loaded from different locations