### PR TITLE
Make inline default option

### DIFF
--- a/packages/core/components/Icon.astro
+++ b/packages/core/components/Icon.astro
@@ -27,7 +27,7 @@ class AstroIconError extends Error {
 }
 
 const req = Astro.request;
-const { name = "", title, desc, "is:inline": inline = false, ...props } = Astro.props;
+const { name = "", title, desc, "is:inline": inline = true, ...props } = Astro.props;
 const map = cache.get(req) ?? new Map();
 const i = map.get(name) ?? 0;
 map.set(name, i + 1);


### PR DESCRIPTION
Make svg loading with inline by default, sprite approach is too limited when components are getting updated